### PR TITLE
修正Docker虚拟化部署的时候nginx进程启动成功，但php-fpm进程启动失败的问题

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,4 @@
 #!/bin/sh
 
-# 后台启动
-php-fpm -D
-# 关闭后台启动，hold住进程
-nginx -g 'daemon off;'
+# 后台启动php-fpm; 关闭nginx后台启动，hold住进程
+php-fpm -D && nginx -g 'daemon off;'


### PR DESCRIPTION
复现方法：在微信云管理后台新建服务的时候直接上传本仓库的代码发布，然后在微信云管理后台进行云端测试，api/count接口报nginx 502错误，后台webshell登录容器后，发现是php-fpm进程没起来。